### PR TITLE
Fix Combination controller

### DIFF
--- a/prestashop-nginx.conf
+++ b/prestashop-nginx.conf
@@ -79,7 +79,7 @@ server {
     rewrite ^/c/([a-zA-Z_-]+)(-[0-9]+)?/.+.jpg$ /img/c/$1$2.jpg last;
     
     # Symfony controllers
-    location ~ /(international|_profiler|module|product)/(.*)$ {
+    location ~ /(international|_profiler|module|product|combination|specific-price)/(.*)$ {
       	try_files $uri $uri/ /index.php?q=$uri&$args $admin_dir/index.php$is_args$args;    	
     }
 


### PR DESCRIPTION
Hi,

Your clause in the conf file for Symphony controllers is incomplete. combinations can't be added in products (generate button does not work).

Two controllers are missing :
- combination
- specific-price

BTW, thanks for your file it helped me a lot !