### PR TITLE
Add 'configure' for URI in the admin panel

### DIFF
--- a/prestashop-nginx.conf
+++ b/prestashop-nginx.conf
@@ -67,7 +67,7 @@ server {
     gzip_disable "MSIE [1-6]\.(?!.*SV1)";
     
     # Symfony controllers
-    location ~ /(international|_profiler|module|product|feature|attribute|supplier|combination|specific-price)/(.*)$ {
+    location ~ /(international|_profiler|module|product|feature|attribute|supplier|combination|specific-price|configure)/(.*)$ {
       	try_files $uri $uri/ /index.php?q=$uri&$args $admin_dir/index.php$is_args$args;    	
     }
 


### PR DESCRIPTION
Prestashop 1.7.3.2 use 'configure' as URI in the Advanced Parameters  (-> Information) i.e http://domain.test/<admin>/index.php/configure/advanced/system_information